### PR TITLE
Fix monitor queue error handling

### DIFF
--- a/src/base/FlowMonitor.ts
+++ b/src/base/FlowMonitor.ts
@@ -88,8 +88,8 @@ export default class FlowMonitor {
     const jobKey = keyFormatter.job(this.flowName, jobId);
     await Promise.all([
       this.redis.lRem(keyFormatter.processingQueueName(queueName), 1, jobId),
-      this.redis.hSet(jobKey, "done", '"true"'),
-      this.redis.hSet(jobKey, "failed", '"true"'),
+      this.redis.hSet(jobKey, "done", "true"),
+      this.redis.hSet(jobKey, "failed", "true"),
       this.redis.hSet(
         jobKey,
         "failedErrorMsg",


### PR DESCRIPTION
Fixes this bug: https://discord.com/channels/697041998728659035/1100897398454222982/1157599643941736539


Tested this way:
```typescript
import { createClient } from "redis";

const redis = createClient();

(async () => {
  await redis.connect();
  await redis.hSet("rossz", "done", '"true"');
  await redis.hSet("jo", "done", "true");
})();
```
```
127.0.0.1:6379> hgetall jo
1) "done"
2) "true"
127.0.0.1:6379> hgetall rossz
1) "done"
2) "\"true\""
```