### PR TITLE
Covalent queue, limiter improvements

### DIFF
--- a/src/base/Queue.ts
+++ b/src/base/Queue.ts
@@ -69,7 +69,14 @@ export default class Queue {
 
     // set properties
     this.name = queueName;
-    this.limiter = limiter;
+    this.limiter = limiter
+      ? {
+          reservoir: limiter.reservoir,
+          intervalMs: limiter.intervalMs,
+          id: limiter.id ?? queueName,
+          groupJobKey: limiter.groupJobKey,
+        }
+      : undefined;
     this.attributesToGet = attributesToGet || [];
     this.priorities = priorities || 1;
     this.delayable = delayable ?? false;

--- a/src/base/QueuesClient.ts
+++ b/src/base/QueuesClient.ts
@@ -175,7 +175,7 @@ export default class QueuesClient {
     Object.entries(job).forEach(([key, value]) => {
       if (key.match(matcher) && value instanceof Array) {
         value.forEach((childJobId) => {
-          transaction.del(childJobId);
+          transaction.del(childJobId as string);
         });
       }
     });
@@ -192,10 +192,7 @@ export default class QueuesClient {
   private getJobs = async <FlowName extends FlowNames>(
     jobIds: string[],
     resolveChildren: boolean
-  ): Promise<
-    (FlowTypes[FlowName]["job"]["params"] &
-      FlowTypes[FlowName]["job"]["result"])[]
-  > => {
+  ): Promise<FlowTypes[FlowName]["content"][]> => {
     const transaction = this.redis.multi();
     jobIds.forEach((jobId) => {
       const jobKey = keyFormatter.job(jobId);
@@ -256,8 +253,7 @@ export default class QueuesClient {
       );
     }
 
-    return jobs as (FlowTypes[FlowName]["job"]["params"] &
-      FlowTypes[FlowName]["job"]["result"])[]; // trust me bro
+    return jobs as FlowTypes[FlowName]["content"][]; // trust me bro
   };
 
   /**
@@ -272,10 +268,7 @@ export default class QueuesClient {
     keyName: FlowTypes[FlowName]["lookupAttributes"],
     value: string | number,
     resolveChildren: boolean
-  ): Promise<
-    (FlowTypes[FlowName]["job"]["params"] &
-      FlowTypes[FlowName]["job"]["result"])[]
-  > => {
+  ): Promise<FlowTypes[FlowName]["content"][]> => {
     // typecheck (necessary because CreateFlowOptions extends AnyObject)
     if (typeof keyName !== "string") {
       return [];
@@ -287,7 +280,7 @@ export default class QueuesClient {
       -1
     );
 
-    return this.getJobs(jobIds, resolveChildren);
+    return this.getJobs<FlowName>(jobIds, resolveChildren);
   };
 
   /**

--- a/src/base/QueuesClient.ts
+++ b/src/base/QueuesClient.ts
@@ -171,7 +171,7 @@ export default class QueuesClient {
     transaction.del(jobKey);
 
     // remove children
-    const matcher = /^children:.*:jobs$/
+    const matcher = /^children:.*:jobs$/;
     Object.entries(job).forEach(([key, value]) => {
       if (key.match(matcher) && value instanceof Array) {
         value.forEach((childJobId) => {
@@ -189,7 +189,13 @@ export default class QueuesClient {
    * @param resolveChildren whether include child jobs (not just their keys)
    * @returns jobs
    */
-  private getJobs = async (jobIds: string[], resolveChildren: boolean) => {
+  private getJobs = async <FlowName extends FlowNames>(
+    jobIds: string[],
+    resolveChildren: boolean
+  ): Promise<
+    (FlowTypes[FlowName]["job"]["params"] &
+      FlowTypes[FlowName]["job"]["result"])[]
+  > => {
     const transaction = this.redis.multi();
     jobIds.forEach((jobId) => {
       const jobKey = keyFormatter.job(jobId);
@@ -250,7 +256,8 @@ export default class QueuesClient {
       );
     }
 
-    return jobs;
+    return jobs as (FlowTypes[FlowName]["job"]["params"] &
+      FlowTypes[FlowName]["job"]["result"])[]; // trust me bro
   };
 
   /**
@@ -265,7 +272,10 @@ export default class QueuesClient {
     keyName: FlowTypes[FlowName]["lookupAttributes"],
     value: string | number,
     resolveChildren: boolean
-  ): Promise<Record<string, any>[]> => {
+  ): Promise<
+    (FlowTypes[FlowName]["job"]["params"] &
+      FlowTypes[FlowName]["job"]["result"])[]
+  > => {
     // typecheck (necessary because CreateFlowOptions extends AnyObject)
     if (typeof keyName !== "string") {
       return [];

--- a/src/base/Worker.ts
+++ b/src/base/Worker.ts
@@ -499,7 +499,10 @@ export default class Worker<
             // else check if worker is still running and retry
             if (job) {
               const isDelayed = await this.delayWrapper(job, priority);
-              if (isDelayed) resolve(0);
+              if (isDelayed) {
+                resolve(0);
+                return;
+              }
 
               const start = performance.now();
               const result = await this.executeWrapper(job, priority);

--- a/src/base/Worker.ts
+++ b/src/base/Worker.ts
@@ -492,7 +492,7 @@ export default class Worker<
             // else check if worker is still running and retry
             if (job) {
               const isDelayed = await this.delayWrapper(job, priority);
-              if (isDelayed) return;
+              if (isDelayed) resolve(0);
 
               const start = performance.now();
               const result = await this.executeWrapper(job, priority);

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -85,6 +85,7 @@ export type ArrayElement<ArrayType> =
 /* ========== Base types ========== */
 
 export type Limiter = {
+  id: string;
   reservoir: number;
   intervalMs: number;
   groupJobKey: string;
@@ -171,7 +172,8 @@ export type QueueOptions<NextQueueName extends string = string> = {
   /**
    * Optional rate limiter options
    */
-  limiter?: Limiter;
+  limiter?: Pick<Limiter, "intervalMs" | "reservoir"> & // required properties
+    Partial<Pick<Limiter, "id" | "groupJobKey">>; // optional properties
 
   /**
    * Number of priorities for this queue

--- a/src/flows/access/getAccessFlowData.ts
+++ b/src/flows/access/getAccessFlowData.ts
@@ -1,17 +1,12 @@
 import Queue from "../../base/Queue";
 import { QueueOptions } from "../../base/types";
 import { AccessFlowJob } from "./types";
-import { manageRewardQueue } from "../sharedQueues";
+import { accessCheckQueue, manageRewardQueue } from "../sharedQueues";
 import { FlowProps } from "../types";
 
 const getAccessFlowProps = (): FlowProps => {
   // most of the access flow jobs need the userId and roleId
-  const defaultAttributesToGet = [
-    "userId",
-    "guildId",
-    "roleIds",
-    "correlationId",
-  ];
+  const defaultAttributesToGet = ["userId", "guildId", "roleIds"];
   // we want to fetch the access flow jobs by userId, roleId, guildId, in the queues
   const lookupAttributes = ["userId", "roleIds", "guildId"];
 
@@ -21,17 +16,7 @@ const getAccessFlowProps = (): FlowProps => {
       queueName: "access-preparation",
       attributesToGet: [...defaultAttributesToGet, "recheckAccess", "guildId"],
     },
-    {
-      queueName: "access-check",
-      attributesToGet: [...defaultAttributesToGet, "requirementIds"],
-      children: [
-        {
-          queueName: "requirement",
-          attributesToGet: ["userId", "requirementId"],
-        },
-      ],
-      nextQueueName: "access-logic",
-    },
+    accessCheckQueue,
     {
       queueName: "access-logic",
       attributesToGet: [

--- a/src/flows/access/types.ts
+++ b/src/flows/access/types.ts
@@ -69,6 +69,7 @@ export type AccessCheckChildParams = {
   childName: "requirement" | "covalent";
   userId: number;
   requirementId: number;
+  priority: number;
 };
 
 /**
@@ -310,3 +311,13 @@ export type AccessFlowJob =
   | AccessResultJob;
 
 export type AccessLookupAttributes = "userId" | "roleIds" | "guildId";
+
+export type AccessJobContent = CreateAccessJobOptions &
+  BaseJobParams &
+  AccessPreparationJob["result"] &
+  AccessCheckJob["result"] &
+  AccessLogicJob["result"] &
+  UpdateMembershipJob["result"] &
+  PrepareManageRewardJob["result"] &
+  ManageRewardJob["result"] &
+  AccessResultJob["result"];

--- a/src/flows/access/types.ts
+++ b/src/flows/access/types.ts
@@ -66,7 +66,7 @@ export type AccessPreparationParams = AccessFlowParams & {
  * Basic properties of requirementCheck
  */
 export type AccessCheckChildParams = {
-  childName: "requirement";
+  childName: "requirement" | "covalent";
   userId: number;
   requirementId: number;
 };
@@ -236,7 +236,7 @@ export type AccessPreparationJob = {
  */
 export type AccessCheckJob = {
   queueName: "access-check";
-  children: [{ queueName: "requirement" }];
+  children: [{ queueName: "requirement" }, { queueName: "covalent" }];
   params: AccessCheckParams;
   result: AccessCheckResult;
 };

--- a/src/flows/sharedQueues.ts
+++ b/src/flows/sharedQueues.ts
@@ -61,6 +61,7 @@ export const accessCheckQueue = new Queue({
     {
       queueName: "requirement",
       attributesToGet: ["userId", "requirementId"],
+      priorities: 2,
     },
     {
       queueName: "covalent",

--- a/src/flows/sharedQueues.ts
+++ b/src/flows/sharedQueues.ts
@@ -3,7 +3,6 @@ import Queue from "../base/Queue";
 // all manage reward child jobs only need the manageRewardAction attribute
 const manageRewardAttributeToGet = ["manageRewardAction"];
 
-// eslint-disable-next-line import/prefer-default-export
 export const manageRewardQueue = new Queue({
   queueName: "manage-reward",
   attributesToGet: [
@@ -41,6 +40,35 @@ export const manageRewardQueue = new Queue({
     {
       queueName: "nft",
       attributesToGet: manageRewardAttributeToGet,
+    },
+  ],
+});
+
+export const accessCheckQueue = new Queue({
+  queueName: "access-check",
+  attributesToGet: [
+    "userId",
+    "guildId",
+    "roleIds",
+    "correlationId",
+    "requirementIds",
+  ],
+  nextQueueMap: new Map([
+    ["access", "access-logic"],
+    ["status-update", "bulk-access-logic"],
+  ]),
+  children: [
+    {
+      queueName: "requirement",
+      attributesToGet: ["userId", "requirementId"],
+    },
+    {
+      queueName: "covalent",
+      attributesToGet: ["userId", "requirementId"],
+      limiter: {
+        reservoir: 4, // 50 in prod, 4 otherwise
+        intervalMs: 1000,
+      },
     },
   ],
 });

--- a/src/flows/sharedQueues.ts
+++ b/src/flows/sharedQueues.ts
@@ -65,6 +65,8 @@ export const accessCheckQueue = new Queue({
     {
       queueName: "covalent",
       attributesToGet: ["userId", "requirementId"],
+      priorities: 2,
+      delayable: true,
       limiter: {
         reservoir: 4, // 50 in prod, 4 otherwise
         intervalMs: 1000,

--- a/src/flows/sharedQueues.ts
+++ b/src/flows/sharedQueues.ts
@@ -69,7 +69,7 @@ export const accessCheckQueue = new Queue({
       priorities: 2,
       delayable: true,
       limiter: {
-        reservoir: 4, // 50 in prod, 4 otherwise
+        reservoir: 45, // 50 in prod, 4 otherwise, we use 45 here just to be safe because some checks may require more calls while others require none
         intervalMs: 1000,
       },
     },

--- a/src/flows/statusUpdate/getStatusUpdateFlowData.ts
+++ b/src/flows/statusUpdate/getStatusUpdateFlowData.ts
@@ -1,16 +1,11 @@
 import Queue from "../../base/Queue";
 import { QueueOptions } from "../../base/types";
-import { manageRewardQueue } from "../sharedQueues";
+import { accessCheckQueue, manageRewardQueue } from "../sharedQueues";
 import { FlowProps } from "../types";
 import { StatusUpdateJob } from "./types";
 
 const getStatusUpdateFlowProps = (): FlowProps => {
-  const defaultAttributesToGet = [
-    "userIds",
-    "guildId",
-    "roleIds",
-    "correlationId",
-  ];
+  const defaultAttributesToGet = ["userIds", "guildId", "roleIds"];
   const lookupAttributes = ["roleIds", "guildId"];
 
   const queueOptions: (QueueOptions<StatusUpdateJob["queueName"]> | Queue)[] = [
@@ -18,6 +13,7 @@ const getStatusUpdateFlowProps = (): FlowProps => {
       queueName: "status-update-preparation",
       attributesToGet: [...defaultAttributesToGet, "recheckAccess", "guildId"],
     },
+    accessCheckQueue,
     {
       queueName: "bulk-access-check",
       attributesToGet: [...defaultAttributesToGet],

--- a/src/flows/statusUpdate/getStatusUpdateFlowData.ts
+++ b/src/flows/statusUpdate/getStatusUpdateFlowData.ts
@@ -2,13 +2,16 @@ import Queue from "../../base/Queue";
 import { QueueOptions } from "../../base/types";
 import { accessCheckQueue, manageRewardQueue } from "../sharedQueues";
 import { FlowProps } from "../types";
-import { StatusUpdateJob } from "./types";
+import { StatusUpdateFlowJob } from "./types";
 
 const getStatusUpdateFlowProps = (): FlowProps => {
   const defaultAttributesToGet = ["userIds", "guildId", "roleIds"];
   const lookupAttributes = ["roleIds", "guildId"];
 
-  const queueOptions: (QueueOptions<StatusUpdateJob["queueName"]> | Queue)[] = [
+  const queueOptions: (
+    | QueueOptions<StatusUpdateFlowJob["queueName"]>
+    | Queue
+  )[] = [
     {
       queueName: "status-update-preparation",
       attributesToGet: [...defaultAttributesToGet, "recheckAccess", "guildId"],

--- a/src/flows/statusUpdate/getStatusUpdateFlowData.ts
+++ b/src/flows/statusUpdate/getStatusUpdateFlowData.ts
@@ -16,7 +16,6 @@ const getStatusUpdateFlowProps = (): FlowProps => {
       queueName: "status-update-preparation",
       attributesToGet: [...defaultAttributesToGet, "recheckAccess", "guildId"],
     },
-    accessCheckQueue,
     {
       queueName: "bulk-access-check",
       attributesToGet: [...defaultAttributesToGet],
@@ -26,8 +25,9 @@ const getStatusUpdateFlowProps = (): FlowProps => {
           attributesToGet: ["userIds", "requirementId"],
         },
       ],
-      nextQueueName: "bulk-access-logic",
+      nextQueueName: "access-check" as StatusUpdateFlowJob["queueName"],
     },
+    accessCheckQueue,
     {
       queueName: "bulk-access-logic",
       attributesToGet: [

--- a/src/flows/statusUpdate/types.ts
+++ b/src/flows/statusUpdate/types.ts
@@ -33,7 +33,7 @@ export type StatusUpdateFlowParams = Omit<
 
 export type StatusUpdateFlowResult = {
   // eslint-disable-next-line no-use-before-define
-  nextQueue?: StatusUpdateJob["queueName"];
+  nextQueue?: StatusUpdateFlowJob["queueName"];
 };
 
 export type StatusUpdatePreparationParams =
@@ -161,7 +161,7 @@ export type StatusUpdateResultJob = {
   result: AccessResultResult;
 };
 
-export type StatusUpdateJob =
+export type StatusUpdateFlowJob =
   | StatusUpdatePreparationJob
   | BulkAccessCheckJob
   | BulkAccessLogicJob
@@ -171,3 +171,13 @@ export type StatusUpdateJob =
   | StatusUpdateResultJob;
 
 export type StatusUpdateLookupAttributes = "roleIds" | "guildId";
+
+export type StatusUpdateJobContent = CreateStatusUpdateJobOptions &
+  BaseJobParams &
+  StatusUpdatePreparationJob["result"] &
+  BulkAccessCheckJob["result"] &
+  BulkAccessLogicJob["result"] &
+  BulkUpdateMembershipJob["result"] &
+  BulkPrepareManageRewardJob["result"] &
+  ManageRewardJob["result"] &
+  StatusUpdateResultJob["result"];

--- a/src/flows/statusUpdate/types.ts
+++ b/src/flows/statusUpdate/types.ts
@@ -46,6 +46,7 @@ export type StatusUpdatePreparationResult = StatusUpdateFlowResult &
     | {
         nextQueue: "bulk-access-check";
         "children:bulk-access-check:params": BulkAccessCheckChildParams[];
+        "children:access-check:params": AccessCheckChildParams[];
       }
     | {
         nextQueue: "bulk-update-membership";

--- a/src/flows/types.ts
+++ b/src/flows/types.ts
@@ -1,23 +1,27 @@
 import Queue from "../base/Queue";
 import {
   AccessFlowJob,
+  AccessJobContent,
   AccessLookupAttributes,
   CreateAccessJobOptions,
 } from "./access/types";
 import {
   CreateStatusUpdateJobOptions,
-  StatusUpdateJob,
+  StatusUpdateFlowJob,
+  StatusUpdateJobContent,
   StatusUpdateLookupAttributes,
 } from "./statusUpdate/types";
 
 export type FlowTypes = {
   access: {
     job: AccessFlowJob;
+    content: AccessJobContent;
     createJobOptions: CreateAccessJobOptions;
     lookupAttributes: AccessLookupAttributes;
   };
   "status-update": {
-    job: StatusUpdateJob;
+    job: StatusUpdateFlowJob;
+    content: StatusUpdateJobContent;
     createJobOptions: CreateStatusUpdateJobOptions;
     lookupAttributes: StatusUpdateLookupAttributes;
   };

--- a/src/static.ts
+++ b/src/static.ts
@@ -33,3 +33,6 @@ export const IS_DELAY_FIELD = "delay";
 export const DELAY_TIMESTAMP_FIELD = "delayReadyTimestamp";
 // the reason why the job was delayed
 export const DELAY_REASON_FIELD = "delayReason";
+
+// whey we don't have a groupJobKey in the limiter, we need a default value for the redis keys
+export const DEFAULT_LIMITER_GROUP_NAME = "default";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -123,8 +123,8 @@ export const keyFormatter = {
     currentTimeWindow: number
   ) =>
     `${COUNTER_KEY_PREFIX}:delay:calls:${queueName}:${groupName}:${currentTimeWindow}`,
-  delayEnqueued: (queueName: string, groupName: string) =>
-    `${COUNTER_KEY_PREFIX}:delay:enqueued:${queueName}:${groupName}`,
+  delayEnqueued: (limiterId: string, groupName: string) =>
+    `${COUNTER_KEY_PREFIX}:delay:enqueued:${limiterId}:${groupName}`,
 };
 
 export const getLookupKeys = (

--- a/tests/common.ts
+++ b/tests/common.ts
@@ -10,9 +10,6 @@ export const testRedisClient = createClient(testRedisClientOptions);
 
 export const testCorrelator: ICorrelator = {
   getId: () => "abc",
-  withId(id, work) {
-    work();
-  },
 };
 
 export const testLogger: ILogger = {


### PR DESCRIPTION
- add new child queue for covalent and make the access-check queue shared between the access-check flow and the status-update flow [(here is a before-after diagram)](https://whimsical.com/access-queue-TGADUnGjaVLEV139AoPxdZ@7YNFXnKbZAc5SBkd25pDj)
- limiter improvement
  - before
    - the limiter can limit job execution per queue
  - now
    - we can define an ID for a limiter and use limiters with the same ID in multiple queues to limit the job execution
    - by default this id will be the queue's name, so it's (100% backwards compatible)
  - this functionality is not utilized yet, because I adopted a different solution, but I think it's good to keep it, it works the same way as before
- define return types for getJobs methods in QueueClient (pas mentioned this in a review and I agreed)
- `leaseWrapper` is updated to avoid 3 sec waits for prio2 jobs [(more info here)](https://discord.com/channels/697041998728659035/1100897398454222982/1172329461702742037)
- fixed delay logic with the new correlationId in the Worker's `eventLoopFunction`

Companion prs: 
- https://github.com/agoraxyz/guild-backend/pull/1126
- https://github.com/agoraxyz/guild-gate/pull/634
- https://github.com/agoraxyz/queue-monitor/pull/13

Checklist
- [ ] update covalent limiter to production