### PR TITLE
Status update improvements

### DIFF
--- a/src/base/Worker.ts
+++ b/src/base/Worker.ts
@@ -401,7 +401,7 @@ export default class Worker<
 
     const result: Result = await Promise.race([
       timeoutPromise,
-      this.workerFunction(job),
+      this.workerFunction(job, timeout),
     ]);
 
     if (timeout) {

--- a/src/base/Worker.ts
+++ b/src/base/Worker.ts
@@ -217,6 +217,17 @@ export default class Worker<
     const itemLockKey = keyFormatter.lock(this.queue.name, job.id);
 
     const jobKey = keyFormatter.job(job.id);
+
+    const existsResult = await this.nonBlockingRedis.exists(jobKey);
+
+    if (existsResult === 0) {
+      this.logger.info(
+        "job completion skipped (job key does not exists)",
+        propertiesToLog
+      );
+      return false;
+    }
+
     const { nextQueue } = result;
 
     const propertiesToSave: AnyObject = result;

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -160,7 +160,7 @@ export type BaseJob = {
 export type WorkerFunction<
   Params extends BaseJobParams,
   Result extends BaseJobResult
-> = (job: Params) => Promise<Result>;
+> = (job: Params, timeout?: ReturnType<typeof setTimeout>) => Promise<Result>;
 
 /* ========== Options ========== */
 


### PR DESCRIPTION
This PR contains 2 fixes:
- Worker should not complete the job if it has been deleted (GUILD-1840), because we should be able to wipe out redis (e.g. emergency) and in these cases in-progress workers would re-write the jobs back to redis when they finish execution [(this change)](https://github.com/agoraxyz/guild-queues/pull/8/files#diff-b4b8d2265b4eaae465d6a4080ff2688aa3ca09c557439e9eb805480b78357c4aR220-R230)
- The issue's name is "Child delay should increase the parent's locktime (GUILD-1521)" but the solution is to periodically update the expiry of the parent when it's running so the locktime and the timeout is no longer needed
  - I was thinking about implementing this to every worker, so each one would have a heartbeat which updates their locks but I think the async execution and the event loop architecture of nodejs could cause issues, e.g. we do a heavy computation, the process is busy, and the locktime update does not happen in time so the job fails, but I'm no expert in this