### PR TITLE
Check if job is actually removed before timing it out + increase EXTRA_LOCK_SEC

### DIFF
--- a/src/base/Worker.ts
+++ b/src/base/Worker.ts
@@ -220,6 +220,7 @@ export default class Worker<
 
     const existsResult = await this.nonBlockingRedis.exists(jobKey);
 
+    // if the job was (most likely externally) deleted, we shouldn't write to redis
     if (existsResult === 0) {
       this.logger.info(
         "job completion skipped (job key does not exists)",

--- a/src/static.ts
+++ b/src/static.ts
@@ -13,7 +13,7 @@ export const DEFAULT_PARENT_CHECK_INTERVAL_MS = 1000;
 // almost all of the keys should expire one day to prevent filling the redis with garbage
 export const DEFAULT_KEY_EXPIRY_SEC = 60 * 60 * 24;
 // additional seconds for the lock key expiration to prevent marking the job failed immediately before finishing it
-export const EXTRA_LOCK_SEC = 1;
+export const EXTRA_LOCK_SEC = 2;
 // this metadata should be included in all logs
 export const DEFAULT_LOG_META = { queues: true };
 export const DEFAULT_PRIORITY = 1;


### PR DESCRIPTION
root of inconsistency:
- worker picks up job
- time passes
- queue-monitor reads the whole queue
- worker finishes the job
- queue-monitor iterates throw the jobIds and checks the locks => lock missing marks completed job as failed (timeout)

[example](https://app.datadoghq.eu/logs?query=env%3Aprod%20%40queueName%3Abulk-update-membership%20%40jobId%3A%22status-update%3A018bfc7a-687e-745d-a8b9-3de64c4f68ad%22%20&cols=host%2Cservice%2C%40queueName&index=%2A&messageDisplay=inline&refresh_mode=paused&stream_sort=desc&view=spans&viz=stream&from_ts=1700747760000&to_ts=1700749320000&live=false)