### PR TITLE
Improve missing lock set

### DIFF
--- a/src/base/FlowMonitor.ts
+++ b/src/base/FlowMonitor.ts
@@ -1,6 +1,6 @@
 import { createClient } from "redis";
 import { DogStatsD, FlowMonitorOptions, ILogger, RedisClient } from "./types";
-import { delay, keyFormatter } from "../utils";
+import { delay, getQueueNameJobIdPair, keyFormatter } from "../utils";
 import {
   DEFAULT_LOG_META,
   DONE_FIELD,
@@ -72,9 +72,10 @@ export default class FlowMonitor {
   public jobIdToPositionMap: Map<string, Position> = new Map();
 
   /**
-   * A set which contains jobIds which had one failed job lock check
+   * A set which contains queueName-jobId pairs which had one failed job lock check
    */
-  public lockMissingJobsIdsSet: Set<string> = new Set();
+  public lockMissingQueueNameJobIdPairsSet: Set<`${string}-${string}`> =
+    new Set();
 
   constructor(options: FlowMonitorOptions) {
     const { redisClientOptions, logger, dogStatsD, intervalMs } = options;
@@ -126,20 +127,22 @@ export default class FlowMonitor {
     priority: number,
     jobId: string
   ) => {
+    const queueNameJobIdPair = getQueueNameJobIdPair(queueName, jobId);
+
     const lock = await this.redis.get(keyFormatter.lock(queueName, jobId));
     if (lock) {
-      this.lockMissingJobsIdsSet.delete(jobId);
+      this.lockMissingQueueNameJobIdPairsSet.delete(queueNameJobIdPair);
       return true;
     }
 
     // if the job fails for the first time, it's possible that the job is just leased but the lock hasn't been inserted yet
-    if (!this.lockMissingJobsIdsSet.has(jobId)) {
+    if (!this.lockMissingQueueNameJobIdPairsSet.has(queueNameJobIdPair)) {
       this.logger.info("Job lock not found for the first time", {
         ...DEFAULT_LOG_META,
         queueName,
         jobId,
       });
-      this.lockMissingJobsIdsSet.add(jobId);
+      this.lockMissingQueueNameJobIdPairsSet.add(queueNameJobIdPair);
       return true;
     }
 
@@ -165,7 +168,7 @@ export default class FlowMonitor {
           jobId,
         }
       );
-      this.lockMissingJobsIdsSet.add(jobId);
+      this.lockMissingQueueNameJobIdPairsSet.delete(queueNameJobIdPair);
       return true;
     }
 
@@ -176,7 +179,7 @@ export default class FlowMonitor {
       [FAILED_ERROR_MSG_FIELD, `"${queueName} lock time exceeded"`],
     ]);
 
-    this.lockMissingJobsIdsSet.delete(jobId);
+    this.lockMissingQueueNameJobIdPairsSet.delete(queueNameJobIdPair);
     return false;
   };
 
@@ -213,6 +216,8 @@ export default class FlowMonitor {
       .exec();
 
     jobIdsToResume.forEach((jobId) => {
+      const queueNameJobIdPair = getQueueNameJobIdPair(queueName, jobId);
+      this.lockMissingQueueNameJobIdPairsSet.delete(queueNameJobIdPair);
       this.logger.info("Job resumed", {
         ...DEFAULT_LOG_META,
         queueName,
@@ -245,6 +250,10 @@ export default class FlowMonitor {
             0,
             -1
           );
+          waitingJobIds.forEach((jobId) => {
+            const queueNameJobIdPair = getQueueNameJobIdPair(queue.name, jobId);
+            this.lockMissingQueueNameJobIdPairsSet.delete(queueNameJobIdPair);
+          });
 
           // processing
           const processingQueueName = keyFormatter.processingQueueName(
@@ -287,6 +296,14 @@ export default class FlowMonitor {
                 readyTimestamp: score,
               })
             );
+
+            delayedJobs.forEach((delayedJob) => {
+              const queueNameJobIdPair = getQueueNameJobIdPair(
+                queue.name,
+                delayedJob.jobId
+              );
+              this.lockMissingQueueNameJobIdPairsSet.delete(queueNameJobIdPair);
+            });
 
             filteredDelayedJobs = await this.resumeDelayedJobs(
               queue.name,
@@ -352,7 +369,7 @@ export default class FlowMonitor {
     ]);
 
     this.logger.info("job lists updated", {
-      lockMissingJobsIdsSetSize: this.lockMissingJobsIdsSet.size,
+      lockMissingJobsIdsSetSize: this.lockMissingQueueNameJobIdPairsSet.size,
     });
   };
 

--- a/src/base/FlowMonitor.ts
+++ b/src/base/FlowMonitor.ts
@@ -216,8 +216,6 @@ export default class FlowMonitor {
       .exec();
 
     jobIdsToResume.forEach((jobId) => {
-      const queueNameJobIdPair = getQueueNameJobIdPair(queueName, jobId);
-      this.lockMissingQueueNameJobIdPairsSet.delete(queueNameJobIdPair);
       this.logger.info("Job resumed", {
         ...DEFAULT_LOG_META,
         queueName,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -169,3 +169,8 @@ export const bindIdToCorrelator = (
 ) => {
   (correlator as any)()({ get: () => id }, null, callback);
 };
+
+export const getQueueNameJobIdPair = (
+  queueName: string,
+  jobId: string
+): `${string}-${string}` => `${queueName}-${jobId}`;


### PR DESCRIPTION
This is a follow up on the #10 PR

## Problem
It's not enough to save the jobId when the lock is missing for the first time, because it's possible that the same event occurs in two queues in the same flow which means the job will be removed from the second queue.
- job is picked up by queue1
- monitor checks job => lock is missing, first time => saves as missingLockJob
- job lock is saved
- job executed, moves to queue2
- job is picked up by queue2
- monitor checks job => lock is missing, second time => marks as failed
- job lock is saved
- job completion is corrupted because it's already marked as failed

[example](https://app.datadoghq.eu/logs?query=env%3Aprod%20%40jobId%3A%22status-update%3A018bfdfc-d5d5-75e4-b7a7-8e67ea9e3533%22%20&cols=host%2Cservice%2C%40queueName&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&view=spans&viz=stream&from_ts=1700694929649&to_ts=1700781329649&live=true)

## Solution
- store queueName-jobId pairs to identify lock misses instead of just storing jobIds
- remove this pair from the set whenever we know it no longer misses a lock (when it appears in the waiting / delayed queue)

