### PR TITLE
Fetch access-check jobs in bulk-access-logic, fix retry logic, add retries to covalent

### DIFF
--- a/src/base/Worker.ts
+++ b/src/base/Worker.ts
@@ -630,6 +630,7 @@ export default class Worker<
         ...propertiesToLog,
         retries,
         maxRetries: this.queue.maxRetries,
+        error,
       });
       return;
     }

--- a/src/base/Worker.ts
+++ b/src/base/Worker.ts
@@ -525,6 +525,7 @@ export default class Worker<
                 ...propertiesToLog,
                 time,
                 job,
+                result,
                 failed: !result,
               });
 

--- a/src/flows/sharedQueues.ts
+++ b/src/flows/sharedQueues.ts
@@ -70,6 +70,7 @@ export const accessCheckQueue = new Queue({
       attributesToGet: ["userId", "guildId", "roleId", "requirementId"],
       priorities: 2,
       delayable: true,
+      maxRetries: 1,
       limiter: {
         reservoir: 30, // 50 in prod, 4 otherwise, we use 30 here just to be safe because some checks may require more calls while others require none
         intervalMs: 1000,

--- a/src/flows/statusUpdate/getStatusUpdateFlowData.ts
+++ b/src/flows/statusUpdate/getStatusUpdateFlowData.ts
@@ -33,6 +33,7 @@ const getStatusUpdateFlowProps = (): FlowProps => {
       queueName: "bulk-access-logic",
       attributesToGet: [
         ...defaultAttributesToGet,
+        "children:access-check:jobs",
         "children:bulk-access-check:jobs",
         "updateMemberships",
       ],

--- a/src/flows/statusUpdate/types.ts
+++ b/src/flows/statusUpdate/types.ts
@@ -74,6 +74,7 @@ export type BulkAccessCheckResult = StatusUpdateFlowResult & {
 };
 
 export type BulkAccessLogicParams = StatusUpdateFlowParams & {
+  "children:access-check:jobs": string[];
   "children:bulk-access-check:jobs": string[];
   updateMemberships: boolean;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -195,7 +195,7 @@ export const handleRetries = async (
   );
   const retriesKey = keyFormatter.retries(queue.name);
 
-  const retries = +(await nonBlockingRedis.hGet(jobId, retriesKey)) || 0;
+  const retries = +(await nonBlockingRedis.hGet(jobKey, retriesKey)) || 0;
 
   if (retries < queue.maxRetries) {
     await nonBlockingRedis


### PR DESCRIPTION
- extra log in Worker.ts
- covalent child queue 1 retry ([related gate PR](https://github.com/guildxyz/guild-gate/pull/643))
- fix error in utils.ts: HGET ~~jobId~~ jobKey
- also fetch `children:access-check:jobs` in bulk access logic, [related BE PR](https://github.com/guildxyz/guild-backend/pull/1167)