### PR TITLE
Remove icon from the Web3Inbox Notification type

### DIFF
--- a/src/flows/messaging/types.ts
+++ b/src/flows/messaging/types.ts
@@ -9,7 +9,6 @@ type Notification = {
   title: string;
   body: string;
   url?: string;
-  icon?: string;
 };
 
 export type MessagingLookupAttributes = "guildId";


### PR DESCRIPTION
### General details

- Linear issue: [GUILD-2082](https://linear.app/guildxyz/issue/GUILD-2082/remove-per-notification-images-for-web3inbox)
- Discord thread: [forum > Messaging](https://discord.com/channels/697041998728659035/1158768674249904178)

### Core implementation details

Did what the Web3Inbox team asked us to do