### PR TITLE
Add galxe child queue for access-check

### DIFF
--- a/src/flows/access/types.ts
+++ b/src/flows/access/types.ts
@@ -68,7 +68,7 @@ export type AccessPreparationParams = AccessFlowParams & {
  * Basic properties of requirementCheck
  */
 export type AccessCheckChildParams = {
-  childName: "requirement" | "covalent";
+  childName: "requirement" | "covalent" | "galxe";
   userId: number;
   guildId: number;
   roleId: number;
@@ -262,7 +262,11 @@ export type AccessPreparationJob = {
  */
 export type AccessCheckJob = {
   queueName: "access-check";
-  children: [{ queueName: "requirement" }, { queueName: "covalent" }];
+  children: [
+    { queueName: "requirement" },
+    { queueName: "covalent" },
+    { queueName: "galxe" }
+  ];
   params: AccessCheckParams;
   result: AccessCheckResult;
 };

--- a/src/flows/sharedQueues.ts
+++ b/src/flows/sharedQueues.ts
@@ -76,6 +76,11 @@ export const accessCheckQueue = new Queue({
       priorities: 2,
     },
     {
+      queueName: "galxe",
+      attributesToGet: ["userId", "guildId", "roleId", "requirementId"],
+      priorities: 2,
+    },
+    {
       queueName: "covalent",
       attributesToGet: ["userId", "guildId", "roleId", "requirementId"],
       priorities: 2,


### PR DESCRIPTION
Same as [for covalent](https://whimsical.com/access-queue-TGADUnGjaVLEV139AoPxdZ@7YNFXnKbZAdCze3r3mzgA). The reason is that the galxe access check often exceed the 180 sec timeout thus block the rest of the jobs. In this PR we separate the galxe jobs, so it won't block any other requirement check (altough it still blocks the join flow, but Balu will create a nice UI so users can so the other accesses and that we are waiting for the galxe check)

![image](https://github.com/guildxyz/guild-queues/assets/56923685/8219910e-6501-4bc9-bfeb-6371494e7a63)
https://app.datadoghq.eu/dashboard/dfd-bq3-tas/queues?index=%2A&refresh_mode=sliding&view=spans&from_ts=1705924615306&to_ts=1705939015306&live=true

Companion PRs:
https://github.com/guildxyz/guild-backend/pull/1228
https://github.com/guildxyz/guild-gate/pull/656
https://github.com/guildxyz/queue-monitor/pull/20