### PR TITLE
Add sender to MessagingJob

### DIFF
--- a/src/flows/messaging/getMessagingFlowData.ts
+++ b/src/flows/messaging/getMessagingFlowData.ts
@@ -13,6 +13,7 @@ const getMessagingProps = (): FlowProps => {
         "protocol",
         "messageId",
         "guildId",
+        "sender",
         "notification",
         "recipients",
         "readyTimestamp",

--- a/src/flows/messaging/getMessagingFlowData.ts
+++ b/src/flows/messaging/getMessagingFlowData.ts
@@ -13,7 +13,7 @@ const getMessagingProps = (): FlowProps => {
         "protocol",
         "messageId",
         "guildId",
-        "sender",
+        "senderUserId",
         "notification",
         "recipients",
         "readyTimestamp",

--- a/src/flows/messaging/types.ts
+++ b/src/flows/messaging/types.ts
@@ -19,6 +19,7 @@ export type MessagingJobOptions = {
   priority: number;
   messageId: number;
   guildId: number;
+  sender: number;
   notification: Notification | string;
   recipients: string[];
   readyTimestamp?: Date;

--- a/src/flows/messaging/types.ts
+++ b/src/flows/messaging/types.ts
@@ -19,7 +19,7 @@ export type MessagingJobOptions = {
   priority: number;
   messageId: number;
   guildId: number;
-  sender: number;
+  senderUserId: number;
   notification: Notification | string;
   recipients: string[];
   readyTimestamp?: Date;


### PR DESCRIPTION
### General details

- Linear issue: [GUILD-1757](https://linear.app/guildxyz/issue/GUILD-1757/key-management-endpoints)
- Discord thread: [forum > Messaging](https://discord.com/channels/697041998728659035/1158768674249904178)

### Core implementation details

Adding a sender field that contains the sender userId to MessagingJob as a part of the key management feature for XMTP.