### PR TITLE
Add children:...:results field to parent queues

### DIFF
--- a/src/base/QueuesClient.ts
+++ b/src/base/QueuesClient.ts
@@ -189,7 +189,7 @@ export default class QueuesClient {
    * @param resolveChildren whether include child jobs (not just their keys)
    * @returns jobs
    */
-  private getJobs = async <FlowName extends FlowNames>(
+  public getJobs = async <FlowName extends FlowNames>(
     jobIds: string[],
     resolveChildren: boolean,
     keysToGet: (keyof FlowTypes[FlowName]["content"])[] = undefined

--- a/src/base/Worker.ts
+++ b/src/base/Worker.ts
@@ -554,7 +554,7 @@ export default class Worker<
   /**
    * Start the job execution
    */
-  public start = async () => {
+  public start = () => {
     const propertiesToLog = {
       ...DEFAULT_LOG_META,
       queueName: this.queue.name,

--- a/src/flows/access/types.ts
+++ b/src/flows/access/types.ts
@@ -351,11 +351,11 @@ export type AccessJobContent = CreateAccessJobOptions &
   Omit<PrepareManageRewardResult, "nextQueue"> &
   Omit<ManageRewardResult, "nextQueue"> &
   Omit<AccessResultResult, "nextQueue"> & {
-    "children:access-check:jobs": (AccessCheckParams &
+    "children:access-check:results": (AccessCheckParams &
       AccessCheckResult &
       BaseJobParams &
       ManagedJobFields)[];
-    "children:manage-reward:jobs": (ManageRewardParams &
+    "children:manage-reward:results": (ManageRewardParams &
       ManageRewardResult &
       BaseJobParams &
       ManagedJobFields)[];

--- a/src/flows/statusUpdate/types.ts
+++ b/src/flows/statusUpdate/types.ts
@@ -188,14 +188,14 @@ export type StatusUpdateJobContent = CreateStatusUpdateJobOptions &
   Omit<BulkPrepareManageRewardResult, "nextQueue"> &
   Omit<ManageRewardResult, "nextQueue"> &
   Omit<StatusUpdateResultResult, "nextQueue"> & {
-    "children:access-check:jobs": (AccessCheckParams &
+    "children:access-check:results": (AccessCheckParams &
       AccessCheckResult &
       BaseJobParams &
       ManagedJobFields)[];
-    "children:bulk-access-check:jobs": (BulkAccessCheckResult &
+    "children:bulk-access-check:results": (BulkAccessCheckResult &
       BaseJobParams &
       ManagedJobFields)[];
-    "children:manage-reward:jobs": (ManageRewardParams &
+    "children:manage-reward:results": (ManageRewardParams &
       ManageRewardResult &
       BaseJobParams &
       ManagedJobFields)[];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -113,6 +113,8 @@ export const keyFormatter = {
   childrenParams: (parentQueueName: string) =>
     `children:${parentQueueName}:params`,
   childrenJobs: (parentQueueName: string) => `children:${parentQueueName}:jobs`,
+  childrenResults: (parentQueueName: string) =>
+    `children:${parentQueueName}:results`,
   childWaitingQueueName: (
     childGroup: string,
     childName: string,


### PR DESCRIPTION
## Context
We have parent-child queues.
A parent queue is a dummy queue, no business logic, just
- creates the pre-defined child jobs (children:...:params field contains the info to create the jobs)
- then periodically checks if ther're done (children:...:jobs field contains the created child job ids)
- if they're done, it finishes

The child jobs are separate jobs, with separate [redis hashes](https://redis.io/docs/data-types/hashes/). 

## Problem
When we have a status-update job with a plenty of child jobs, it's really hard and long to query all the child jobs. Let's say we have a guild with 200k members, and if we want to ask how many of the access check jobs was successful, we need to make 200k+ requests to the redis, which ofc won't really work in an acceptable time, and we even want to poll this endpoint periodically.

## Solution
The parent queue won't just check if the child jobs are done, but when they are, **it will also save children's result to a filed in the parent job (to the children:...:results field)**, so the querying happens here and only once.
Then, when we want to query the status-update job, it's enough to just query the parent jobs, because they contain the results of its child queues.

## Pros and cons
This approach is easy to understand and very easy to implement, but it also uses a lot more memory both in the redis, and in the app. The former is not that much of a problem, but the latter can have unpleasant consequences, so we have to keep this in mind. Also when the parent realizes that all the childs are done, then it has to query all the job's contents, so there could be a CPU+memory spike and the parent workers run at the regular instances at the moment so let's keep that in mind as well. And lastly it would be nice if we didn't log these huge jsons anywhere. :D

## Benchmark

In my 12 core potato I could query a 180k guild's status update with the detailed flag in ~500ms (instead of 1m 35s)

## Miscellaneous

Companion core pr: https://github.com/guildxyz/guild-backend/pull/1276

*also: made getJobs method public, that's for the periodic sync*