### PR TITLE
Make QueueClient.workers public

### DIFF
--- a/src/base/QueuesClient.ts
+++ b/src/base/QueuesClient.ts
@@ -3,7 +3,6 @@ import {
   ArrayElement,
   ICorrelator,
   ILogger,
-  IStartable,
   RedisClient,
   WorkerFunction,
 } from "./types";
@@ -24,7 +23,7 @@ export default class QueuesClient {
   /**
    * Worker instances
    */
-  private workers: IStartable[] = [];
+  public readonly workers: Worker<any, any>[] = [];
 
   /**
    * Options to create redis connections

--- a/src/base/Worker.ts
+++ b/src/base/Worker.ts
@@ -8,7 +8,6 @@ import {
   ILogger,
   RedisClient,
   WorkerOptions,
-  IStartable,
   BaseJobResult,
   AnyObject,
   ICorrelator,
@@ -45,8 +44,7 @@ import {
 export default class Worker<
   Params extends BaseJobParams,
   Result extends BaseJobResult
-> implements IStartable
-{
+> {
   /**
    * Uuid of the worker
    */

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -30,16 +30,6 @@ export interface ILogger {
 }
 
 /**
- * Has connect, disconnect, start and stop method
- */
-export interface IStartable {
-  connect(): void;
-  disconnect(): void;
-  start(): void;
-  stop(): void;
-}
-
-/**
  * Can bind and provide correlation id
  */
 export type ICorrelator = {


### PR DESCRIPTION
Made `QueueClient.workers` property public, removed unnecessary interface.
Related https://github.com/guildxyz/guild-backend/pull/1295