### PR TITLE
Improve key expirations

### DIFF
--- a/src/base/ParentWorker.ts
+++ b/src/base/ParentWorker.ts
@@ -3,6 +3,7 @@
 import {
   delay,
   generateJobId,
+  getKeyExpirySec,
   keyFormatter,
   objectToStringEntries,
   parseObject,
@@ -16,7 +17,6 @@ import {
   WorkerFunction,
 } from "./types";
 import {
-  DEFAULT_KEY_EXPIRY_SEC,
   DEFAULT_LOG_META,
   DEFAULT_PARENT_CHECK_INTERVAL_MS,
   DONE_FIELD,
@@ -99,7 +99,7 @@ export default class ParentWorker extends Worker<BaseJobParams, BaseJobResult> {
 
         // create child job state
         transaction.hSet(childJobKey, objectToStringEntries(childJob));
-        transaction.expire(childJobKey, DEFAULT_KEY_EXPIRY_SEC);
+        transaction.expire(childJobKey, getKeyExpirySec(job.flowName));
         // put it to the child queue
         transaction.rPush(childQueueKey, childJobId);
 

--- a/src/base/ParentWorker.ts
+++ b/src/base/ParentWorker.ts
@@ -99,7 +99,10 @@ export default class ParentWorker extends Worker<BaseJobParams, BaseJobResult> {
 
         // create child job state
         transaction.hSet(childJobKey, objectToStringEntries(childJob));
-        transaction.expire(childJobKey, getKeyExpirySec(job.flowName));
+        transaction.expire(
+          childJobKey,
+          getKeyExpirySec(childJob.flowName, childJob.priority)
+        );
         // put it to the child queue
         transaction.rPush(childQueueKey, childJobId);
 

--- a/src/base/QueuesClient.ts
+++ b/src/base/QueuesClient.ts
@@ -103,7 +103,7 @@ export default class QueuesClient {
     // generate id for the job
     const jobId = generateJobId(flowName);
     const jobKey = keyFormatter.job(jobId);
-    const keyExpirySec = getKeyExpirySec(flowName);
+    const keyExpirySec = getKeyExpirySec(flowName, options.priority);
 
     const transaction = this.redis
       .multi()

--- a/src/base/QueuesClient.ts
+++ b/src/base/QueuesClient.ts
@@ -10,12 +10,12 @@ import Worker from "./Worker";
 import { FlowNames, FlowTypes } from "../flows/types";
 import {
   generateJobId,
+  getKeyExpirySec,
   getLookupKeys,
   keyFormatter,
   objectToStringEntries,
   parseObject,
 } from "../utils";
-import { DEFAULT_KEY_EXPIRY_SEC } from "../static";
 import flows from "../flows/flows";
 import ParentWorker from "./ParentWorker";
 
@@ -103,6 +103,7 @@ export default class QueuesClient {
     // generate id for the job
     const jobId = generateJobId(flowName);
     const jobKey = keyFormatter.job(jobId);
+    const keyExpirySec = getKeyExpirySec(flowName);
 
     const transaction = this.redis
       .multi()
@@ -114,7 +115,7 @@ export default class QueuesClient {
           flowName,
         })
       )
-      .expire(jobKey, DEFAULT_KEY_EXPIRY_SEC);
+      .expire(jobKey, keyExpirySec);
 
     // add lookup keys
     const lookupKeys = getLookupKeys(
@@ -124,7 +125,7 @@ export default class QueuesClient {
     );
     lookupKeys.forEach((lookupKey) => {
       transaction.rPush(lookupKey, jobId);
-      transaction.expire(lookupKey, DEFAULT_KEY_EXPIRY_SEC);
+      transaction.expire(lookupKey, keyExpirySec);
     });
 
     // put to the first queue

--- a/src/base/Worker.ts
+++ b/src/base/Worker.ts
@@ -354,7 +354,7 @@ export default class Worker<
     const [calls, _] = await this.nonBlockingRedis
       .multi()
       .incr(delayCallsKey)
-      .expire(delayCallsKey, getKeyExpirySec(job.flowName))
+      .expire(delayCallsKey, getKeyExpirySec(job.flowName, job.priority))
       .exec();
 
     if (calls > this.queue.limiter.reservoir) {

--- a/src/base/Worker.ts
+++ b/src/base/Worker.ts
@@ -21,6 +21,7 @@ import {
   bindIdToCorrelator,
   delay,
   handleRetries,
+  getKeyExpirySec,
 } from "../utils";
 import {
   DEFAULT_LIMITER_GROUP_NAME,
@@ -350,7 +351,11 @@ export default class Worker<
       currentTimeWindow
     );
 
-    const calls = await this.nonBlockingRedis.incr(delayCallsKey);
+    const [calls, _] = await this.nonBlockingRedis
+      .multi()
+      .incr(delayCallsKey)
+      .expire(delayCallsKey, getKeyExpirySec(job.flowName))
+      .exec();
 
     if (calls > this.queue.limiter.reservoir) {
       const delayEnqueuedKey = keyFormatter.delayEnqueued(

--- a/src/static.ts
+++ b/src/static.ts
@@ -12,6 +12,8 @@ export const DEFAULT_WAIT_TIMEOUT_SEC = 3;
 export const DEFAULT_PARENT_CHECK_INTERVAL_MS = 1000;
 // almost all of the keys should expire one day to prevent filling the redis with garbage
 export const DEFAULT_KEY_EXPIRY_SEC = 60 * 60 * 24;
+// the access flow keys need to expire faster because they can easily fill the redis
+export const ACCESS_FLOW_KEY_EXPIRY_SEC = 60 * 60 * 3;
 // additional seconds for the lock key expiration to prevent marking the job failed immediately before finishing it
 export const EXTRA_LOCK_SEC = 2;
 // this metadata should be included in all logs

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -218,8 +218,14 @@ export const handleRetries = async (
  * Keys need to expire to keep the redis clean. Some flows are usually faster,
  * so it's okay to expire its keys after a shorter amount of time.
  */
-export const getKeyExpirySec = (flowName: string) => {
-  if (flowName.startsWith("access")) {
+export const getKeyExpirySec = (flowName: string, priority: number) => {
+  // the child job's flowName is composed of the parent queue name + the child group (e.g. access-check:requirement), and not the actual flow, so we have to do it this way at the moment
+  if (
+    flowName === "access" ||
+    (priority === 1 &&
+      (flowName.startsWith("access-check") ||
+        flowName.startsWith("manage-reward")))
+  ) {
     return ACCESS_FLOW_KEY_EXPIRY_SEC;
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -215,8 +215,8 @@ export const handleRetries = async (
 };
 
 /**
- * Keys need to expiry to keep the redis clean. Some flows are usually faster,
- * so it's okay to expiry its keys after a shorter amount of time.
+ * Keys need to expire to keep the redis clean. Some flows are usually faster,
+ * so it's okay to expire its keys after a shorter amount of time.
  */
 export const getKeyExpirySec = (flowName: string) => {
   if (flowName.startsWith("access")) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,9 @@ import Queue from "./base/Queue";
 import { AnyObject, ICorrelator, ILogger, RedisClient } from "./base/types";
 import { FlowNames } from "./flows/types";
 import {
+  ACCESS_FLOW_KEY_EXPIRY_SEC,
   COUNTER_KEY_PREFIX,
+  DEFAULT_KEY_EXPIRY_SEC,
   DEFAULT_LOG_META,
   JOB_KEY_PREFIX,
   LOCK_KEY_PREFIX,
@@ -210,4 +212,16 @@ export const handleRetries = async (
   }
 
   return { retried: false };
+};
+
+/**
+ * Keys need to expiry to keep the redis clean. Some flows are usually faster,
+ * so it's okay to expiry its keys after a shorter amount of time.
+ */
+export const getKeyExpirySec = (flowName: string) => {
+  if (flowName.startsWith("access")) {
+    return ACCESS_FLOW_KEY_EXPIRY_SEC;
+  }
+
+  return DEFAULT_KEY_EXPIRY_SEC;
 };


### PR DESCRIPTION
## Problem
![image](https://github.com/guildxyz/guild-queues/assets/56923685/4dc1dd36-0b6b-40e2-b4a5-cfa783d52c57)

## Solution
At first we will reduce the expiration of the access flow related keys in redis from 24h to 3h.
The affected keys are:
- the hashes which store the job data
- the hashes which store the child job data
- the counter:delay:calls:* keys which control the rate limits (how many calls are made in that time bucket)
  - these are probably not responsible for the out of memory incident because they're just integers but they don't have an expiration and create garbage in the long run

Further improvements include: consider an expiration for the counter:delay:enqueued:* keys which store the info about how many jobs are currently delayed. It can be risky to set an expiration for this because the delay queue can take much time to complete, and I'm not sure whether these are mixed between flows, so this can be done later.