### PR TITLE
fix(.npmignore): support new NPM version

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,5 @@
 node_modules/
-src/
+/src/
 tests/
 docs/
 img/

--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,4 @@ git-ignored/
 tsconfig.json
 .eslintrc.json
 README.md
+jest.config.js


### PR DESCRIPTION
- The current LTS node uses a version of NPM (10.5.0), which introduced some changes to how the `.npmignore` file is interpreted. The `src/` entry is now evaluated recursively, therefore it ignores the src directory in the `build` directory as well after the lib is built. Changes it to `/src/` which is not evaluated recursively
- Added the jest config file to `.npmignore`
- Can be tested by running `npm pack --dry-run`, without the changes, it shouldn't print the build output, therefore it gets discarded when the lib is installed in another project. With the changes, it should print the build output, the readme, and the package.json file