### PR TITLE
Don't throw error in deleteJob if job does not exist

### DIFF
--- a/src/base/QueuesClient.ts
+++ b/src/base/QueuesClient.ts
@@ -153,7 +153,7 @@ export default class QueuesClient {
     const [job] = await this.getJobs([jobId], false);
 
     if (!job) {
-      throw new Error("Job to delete does not exist.");
+      return [];
     }
 
     const transaction = this.redis.multi();


### PR DESCRIPTION
It's a quick fix which actually makes sense although we haven't identified the root of the cause yet.