### PR TITLE
Points snapshot

### DIFF
--- a/src/base/Worker.ts
+++ b/src/base/Worker.ts
@@ -22,6 +22,7 @@ import {
   delay,
   handleRetries,
   getKeyExpirySec,
+  getRetries,
 } from "../utils";
 import {
   DEFAULT_LIMITER_GROUP_NAME,
@@ -507,6 +508,13 @@ export default class Worker<
                 resolve(0);
                 return;
               }
+
+              const retries = await getRetries(
+                job.id,
+                this.queue,
+                this.nonBlockingRedis
+              );
+              job.retries = retries;
 
               const start = performance.now();
               const { result, error } = await this.executeWithDeadline(job);

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -103,6 +103,7 @@ export type BaseJobParams = {
   priority: number;
   correlationId: string;
   delay?: boolean;
+  retries?: number;
 };
 
 /**

--- a/src/flows/flows.ts
+++ b/src/flows/flows.ts
@@ -1,16 +1,19 @@
 import getAccessFlowProps from "./access/getAccessFlowData";
 import getMessagingProps from "./messaging/getMessagingFlowData";
 import getStatusUpdateFlowProps from "./statusUpdate/getStatusUpdateFlowData";
+import getSnapshotFlowProps from "./snapshot/getSnapshotFlowData";
 import { Flows } from "./types";
 
 const accessFlowData = getAccessFlowProps();
 const statusUpdateFlowData = getStatusUpdateFlowProps();
 const messagingFlowData = getMessagingProps();
+const snapshotFlowData = getSnapshotFlowProps();
 
 const flows: Flows = {
   access: accessFlowData,
   "status-update": statusUpdateFlowData,
   messaging: messagingFlowData,
+  "points-snapshot": snapshotFlowData,
 };
 
 export default flows;

--- a/src/flows/snapshot/getSnapshotFlowData.ts
+++ b/src/flows/snapshot/getSnapshotFlowData.ts
@@ -10,11 +10,8 @@ const getSnapshotProps = (): FlowProps => {
     [
       {
         queueName: "take-points-snapshot",
-        attributesToGet: [
-          // 2) ide ugyan az kell mint ami PointsSnapshotJobOptions-ben van
-          "guildId",
-          "doStatusUpddate",
-        ],
+        attributesToGet: ["guildId", "guildPlatformId", "snapshotId"],
+        maxRetries: 10,
       },
     ];
 

--- a/src/flows/snapshot/getSnapshotFlowData.ts
+++ b/src/flows/snapshot/getSnapshotFlowData.ts
@@ -1,0 +1,34 @@
+import Queue from "../../base/Queue";
+import { QueueOptions } from "../../base/types";
+import { FlowProps } from "../types";
+import { PointsSnapshotJob } from "./types";
+
+const getSnapshotProps = (): FlowProps => {
+  const lookupAttributes = ["guildId"];
+
+  const queueOptions: (QueueOptions<PointsSnapshotJob["queueName"]> | Queue)[] =
+    [
+      {
+        queueName: "take-points-snapshot",
+        attributesToGet: [
+          // 2) ide ugyan az kell mint ami PointsSnapshotJobOptions-ben van
+          "guildId",
+          "doStatusUpddate",
+        ],
+      },
+    ];
+
+  const queues = queueOptions.map((queueOption) => {
+    if (queueOption instanceof Queue) {
+      return queueOption;
+    }
+    return new Queue(queueOption);
+  });
+
+  return {
+    queues,
+    lookupAttributes,
+  };
+};
+
+export default getSnapshotProps;

--- a/src/flows/snapshot/getSnapshotFlowData.ts
+++ b/src/flows/snapshot/getSnapshotFlowData.ts
@@ -10,7 +10,12 @@ const getSnapshotProps = (): FlowProps => {
     [
       {
         queueName: "take-points-snapshot",
-        attributesToGet: ["guildId", "guildPlatformId", "snapshotId"],
+        attributesToGet: [
+          "guildId",
+          "guildPlatformId",
+          "snapshotId",
+          "shouldStatusUpdate",
+        ],
         maxRetries: 10,
       },
     ];

--- a/src/flows/snapshot/getSnapshotFlowData.ts
+++ b/src/flows/snapshot/getSnapshotFlowData.ts
@@ -1,5 +1,6 @@
 import Queue from "../../base/Queue";
 import { QueueOptions } from "../../base/types";
+import { POINTS_SNAPSHOT_QUEUE_MAX_RETRIES } from "../../static";
 import { FlowProps } from "../types";
 import { PointsSnapshotJob } from "./types";
 
@@ -16,7 +17,7 @@ const getSnapshotProps = (): FlowProps => {
           "snapshotId",
           "shouldStatusUpdate",
         ],
-        maxRetries: 10,
+        maxRetries: POINTS_SNAPSHOT_QUEUE_MAX_RETRIES,
       },
     ];
 

--- a/src/flows/snapshot/types.ts
+++ b/src/flows/snapshot/types.ts
@@ -11,6 +11,7 @@ export type PointsSnapshotJobOptions = {
   guildId: number;
   guildPlatformId: number;
   snapshotId: number;
+  shouldStatusUpdate: boolean;
 };
 
 export type PointsSnapshotJobResult = BaseJobResult & { done: true };

--- a/src/flows/snapshot/types.ts
+++ b/src/flows/snapshot/types.ts
@@ -1,0 +1,29 @@
+import {
+  BaseJobParams,
+  BaseJobResult,
+  ManagedJobFields,
+} from "../../base/types";
+
+// Message => snpshost mindent
+
+export type PointsSnapshotLookupAttributes = "guildId";
+
+export type PointsSnapshotJobOptions = {
+  priority: number;
+  guildId: number;
+  doStatusUpddate: boolean; // 1) ide kell belerakni hogy mi lesz a workerFunction parametereben
+};
+
+export type PointsSnapshotJobResult = BaseJobResult & { done: true };
+
+export type PointsSnapshotJob = {
+  queueName: "take-points-snaphost";
+  children: [];
+  params: BaseJobParams & PointsSnapshotJobOptions;
+  result: PointsSnapshotJobResult;
+};
+
+export type PointsSnapshotContent = PointsSnapshotJobOptions &
+  BaseJobParams &
+  ManagedJobFields &
+  PointsSnapshotJob["result"];

--- a/src/flows/snapshot/types.ts
+++ b/src/flows/snapshot/types.ts
@@ -9,7 +9,7 @@ export type PointsSnapshotLookupAttributes = "guildId";
 export type PointsSnapshotJobOptions = {
   priority: number;
   guildId: number;
-  guildPlatformId: string;
+  guildPlatformId: number;
   snapshotId: number;
 };
 

--- a/src/flows/snapshot/types.ts
+++ b/src/flows/snapshot/types.ts
@@ -4,20 +4,19 @@ import {
   ManagedJobFields,
 } from "../../base/types";
 
-// Message => snpshost mindent
-
 export type PointsSnapshotLookupAttributes = "guildId";
 
 export type PointsSnapshotJobOptions = {
   priority: number;
   guildId: number;
-  doStatusUpddate: boolean; // 1) ide kell belerakni hogy mi lesz a workerFunction parametereben
+  guildPlatformId: string;
+  snapshotId: number;
 };
 
 export type PointsSnapshotJobResult = BaseJobResult & { done: true };
 
 export type PointsSnapshotJob = {
-  queueName: "take-points-snaphost";
+  queueName: "take-points-snapshot";
   children: [];
   params: BaseJobParams & PointsSnapshotJobOptions;
   result: PointsSnapshotJobResult;

--- a/src/flows/types.ts
+++ b/src/flows/types.ts
@@ -12,6 +12,12 @@ import {
   MessagingLookupAttributes,
 } from "./messaging/types";
 import {
+  PointsSnapshotContent,
+  PointsSnapshotJob,
+  PointsSnapshotJobOptions,
+  PointsSnapshotLookupAttributes,
+} from "./snapshot/types";
+import {
   CreateStatusUpdateJobOptions,
   StatusUpdateFlowJob,
   StatusUpdateJobContent,
@@ -36,6 +42,12 @@ export type FlowTypes = {
     content: MessagingContent;
     createJobOptions: MessagingJobOptions;
     lookupAttributes: MessagingLookupAttributes;
+  };
+  "points-snapshot": {
+    job: PointsSnapshotJob;
+    content: PointsSnapshotContent;
+    createJobOptions: PointsSnapshotJobOptions;
+    lookupAttributes: PointsSnapshotLookupAttributes;
   };
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ export * from "./flows/flows";
 export * from "./flows/access/types";
 export * from "./flows/statusUpdate/types";
 export * from "./flows/messaging/types";
+export * from "./flows/snapshot/types";

--- a/src/static.ts
+++ b/src/static.ts
@@ -4,6 +4,8 @@ export const LOCK_KEY_PREFIX = "lock";
 export const JOB_KEY_PREFIX = "job";
 export const COUNTER_KEY_PREFIX = "counter";
 
+export const POINTS_SNAPSHOT_QUEUE_MAX_RETRIES = 10;
+
 // lease a job for this amount of time
 export const DEFAULT_LOCK_SEC = 60 * 3;
 // wait this amount of time for jobs before checking if the worker is still running


### PR DESCRIPTION
new flow added: `points-snapshot`
new queue added: `take-points-snapshot`

This queue will manage the status update before a points snapshot. The jobs in this queue will poll the `syncJobs` and if its finished, it will take the point snapshot.

related core pr [here](https://github.com/guildxyz/guild-backend/pull/1371/files#diff-901bfe79af7568487874eb4047e9366ec987658e1b0c3c618cd4eb5eae79b560)