### PR TITLE
Move saveClaimData to access-preparation

### DIFF
--- a/src/flows/access/getAccessFlowData.ts
+++ b/src/flows/access/getAccessFlowData.ts
@@ -14,7 +14,12 @@ const getAccessFlowProps = (): FlowProps => {
   const queueOptions: (QueueOptions<AccessFlowJob["queueName"]> | Queue)[] = [
     {
       queueName: "access-preparation",
-      attributesToGet: [...defaultAttributesToGet, "recheckAccess", "guildId"],
+      attributesToGet: [
+        ...defaultAttributesToGet,
+        "recheckAccess",
+        "saveClaimData",
+        "guildId",
+      ],
     },
     accessCheckQueue,
     {
@@ -32,7 +37,6 @@ const getAccessFlowProps = (): FlowProps => {
         "roleAccesses",
         "manageRewards",
         "shareSocials",
-        "saveClaimData",
         "rootAuditLogId",
       ],
     },


### PR DESCRIPTION
Accidentally left it in update membership's attributes since that's where I originally planned to add it