### PR TITLE
Add flowId to base job params

### DIFF
--- a/src/base/Queue.ts
+++ b/src/base/Queue.ts
@@ -104,6 +104,7 @@ export default class Queue {
       "flowName",
       "priority",
       "correlationId",
+      "flowId",
     ];
     if (delayable) {
       defaultAttributesToGet.push("delay");

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -103,6 +103,7 @@ export type BaseJobParams = {
   flowName: FlowNames;
   priority: number;
   correlationId: string;
+  flowId?: string;
   delay?: boolean;
   retries?: number;
 };


### PR DESCRIPTION
This pr fixes a bug with the core2 gate1 access flow. The core2 listener saves jobs done count by flow id in redis, and since the queues doesn't include it in the job params it gets returned as null.
Because of this running a status update on a role a second time will not trigger the `checkIfAllDone` logic because `roleSummary.Count` will be more than `allDone`.

I didn't test it yet just wanted your opinion on it, maybe you'll immediately see if there's something wrong with it. I'm not sure if it will mess up the flows where there's no flowId in the redis hasmap. Although I tried it in redis and it just returns nil in that case.